### PR TITLE
Recommend npx instead of npm scripts in docs #836

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -20,26 +20,13 @@ npm install --save-dev react-styleguidist
 
 [Point Styleguidist to your React components](Components.md) and [tell it how to load your code](Webpack.md).
 
-## 3. Add npm scripts for convenience
-
-Add these scripts to your `package.json`:
-
-```diff
-{
-  "scripts": {
-+    "styleguide": "styleguidist server",
-+    "styleguide:build": "styleguidist build"
-  }
-}
-```
-
-## 4. Start your style guide
+## 3. Start your style guide
 
 Run **`npx styleguidist server`** to start a style guide dev server.
 
 Run **`npx styleguidist build`** to build a static version.
 
-## 5. Start documenting your components
+## 4. Start documenting your components
 
 See how to [document your components](Documenting.md)
 


### PR DESCRIPTION
- Replaced all npm run styleguide with npx styleguidist server.
- Replaced all npm run styleguide:build with npx styleguidist build.
- Removed 3rd item 'Add npm scripts for convenience' in the getting started guide.